### PR TITLE
fix(python): allow uppercase on LDAP

### DIFF
--- a/update-spec.py
+++ b/update-spec.py
@@ -244,6 +244,18 @@ json_spec['components']['schemas']['ReadLdapServerXo']['required'] = temp_requir
 json_spec['components']['schemas']['UpdateLdapServerXo']['required'] = temp_required
 print('Done')
 
+print('Patching ReadLdapServerXo enum values to also accept uppercase...')
+for prop in ['groupType', 'protocol']:
+    if prop in json_spec['components']['schemas']['ReadLdapServerXo']['properties']:
+        prop_def = json_spec['components']['schemas']['ReadLdapServerXo']['properties'][prop]
+        if 'enum' in prop_def:
+            existing = prop_def['enum']
+            for val in existing:
+                upper = val.upper()
+                if upper not in existing:
+                    existing.append(upper)
+print('Done')
+
 # Not required from NXRM 3.85.0 onwards
 # print('Fixing response schema for IQ Connection...')
 # json_spec['paths']['/v1/iq']['get']['responses']['200']['content'] = {


### PR DESCRIPTION
The latest community edition breaks the List endpoint for LDAP servers and does not return a spec conform response. I encountered this for the two enums fixed in this PR, cannot say whether other fields are affected as well